### PR TITLE
NEP2: Suggest bytes be UInt8

### DIFF
--- a/draft/0002-streamable-bodies.md
+++ b/draft/0002-streamable-bodies.md
@@ -39,13 +39,13 @@ response bodies. This avoids loading the whole body into memory at once.
 ## Rationale
 
 This NEP proposes adding a `PayloadType` protocol which contains a
-mutating method called `next` which returns an optional `Int8`.
+mutating method called `next` which returns an optional `UInt8`.
 
 ```swift
 /// Represents a HTTP request or response body<F24><F25>
 protocol PayloadType {
   /// Returns the next byte in the payload
-  mutating func next() -> Int8?
+  mutating func next() -> UInt8?
 }
 ```
 


### PR DESCRIPTION
From working with data in Swift recently, most of the time it's useful to represent bytes as `UInt8` type instead of the signed `Int8`.

If you're using these bytes for passing around strings in UTF-8, it's `CodeUnit` is `UInt8`. I'd argue that's the most frequent use case.
In the rest of the cases, when treating data as just raw bytes, `UInt8` is assumed.

So I think changing the type to `UInt8` would be beneficial. 
